### PR TITLE
issue 382: fix updates for files with space in name

### DIFF
--- a/src/VASL/build/module/map/BoardVersionChecker.java
+++ b/src/VASL/build/module/map/BoardVersionChecker.java
@@ -36,6 +36,7 @@ import javax.swing.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.*;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.Channels;
@@ -260,7 +261,7 @@ public class BoardVersionChecker extends AbstractBuildable implements GameCompon
         InputStream in = null;
         try {
 
-            URL website = new URL(url);
+            URL website = new URL( encodeUrl(url) );
             URLConnection conn = website.openConnection();
             conn.setUseCaches(false);
 
@@ -278,6 +279,21 @@ public class BoardVersionChecker extends AbstractBuildable implements GameCompon
         finally {
             IOUtils.closeQuietly(outFile);
             IOUtils.closeQuietly(in);
+        }
+    }
+    
+    // do not use on an already-encoded URL. It will double-encode it.
+    private static String encodeUrl( String unencodedURL ) {
+        try {
+            URL url = new URL(unencodedURL);
+            URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef()); 
+            return uri.toURL().toString();
+        }
+        catch( java.net.URISyntaxException ex ) {
+            return unencodedURL;
+        }
+        catch( java.net.MalformedURLException ex ) {
+            return unencodedURL;
         }
     }
 }


### PR DESCRIPTION
fixes #382 
Paths for boards with spaces in their names were not encoded correctly, i.e. with %0020. When vasl attempted to download a later version of a board, in my limited testing sometimes it worked anyway and sometimes it didn't. This should fix the more general case when any special character needs to be encoded, although I am not sure there are any such cases in the current maps.