### PR TITLE
Updated VASSAL to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.vassalengine</groupId>
             <artifactId>vassal-app</artifactId>
-            <version>3.4.0-beta1</version>
+            <version>3.4.0</version>
         </dependency>
 
         <!-- We do not have any tests yet, but time will tell... -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.vassalengine</groupId>
             <artifactId>vassal-app</artifactId>
-            <version>3.3.3-alpha2</version>
+            <version>3.4.0-beta1</version>
         </dependency>
 
         <!-- We do not have any tests yet, but time will tell... -->

--- a/src/VASL/build/module/ASLChatter.java
+++ b/src/VASL/build/module/ASLChatter.java
@@ -483,7 +483,8 @@ public class ASLChatter extends VASSAL.build.module.Chatter
             objButton.setToolTipText(strTooltipText + " [" + HotKeyConfigurer.getString(objListener.getKeyStroke()) + "]");
     }
 
-    private String formatChat(String text)
+    @Override
+    protected String formatChat(String text)
     {
         final String id = GlobalOptions.getInstance().getPlayerId();
 


### PR DESCRIPTION
We released 3.4.0-beta1 a few minutes ago. You'll want to update to building against that.

(We're not releasing 3.3.3. Instead, what was going to be 3.3.3 and 3.3.4 will be released as 3.4.0 after this beta.)