### PR TITLE
#833 update vasl to use vassal3.5.0-beta2

### DIFF
--- a/dist/buildFile
+++ b/dist/buildFile
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<VASSAL.launch.BasicModule VassalVersion="3.4.6" description="Virtual Advanced Squad Leader" name="VASL" nextPieceSlotId="13707" version="6.6.2">
+<VASSAL.launch.BasicModule VassalVersion="3.5.0-beta2" description="Virtual Advanced Squad Leader" name="VASL" nextPieceSlotId="13707" version="6.6.2">
     <VASL.build.module.OBA hotkey="117,0"/>
     <VASL.build.module.ScenInfo/>
     <VASL.build.module.CounterPaletteSearch/>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.vassalengine</groupId>
             <artifactId>vassal-app</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.0-beta2</version>
         </dependency>
 
         <!-- We do not have any tests yet, but time will tell... -->
@@ -101,7 +101,7 @@
                     <arguments>
                         <argument>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</argument>
                         <argument>-jar</argument>
-                        <argument>Vengine-3.4.6.jar</argument>
+                        <argument>Vengine-3.5.0-beta2.jar</argument>
                         <argument>--standalone</argument>
                         <argument>target/${project.build.finalName}.jar</argument>
                     </arguments>


### PR DESCRIPTION
As part of the move to use vassal3.5.0 to build and run vasl, this commit moves vasl to use vassal3.5.0-beta2. I expect that vasl6.6.2 will released using vassal3.5.0 later this spring. 