### PR TITLE
#764 Fix Java (*not VASSAL*) deprecated code

### DIFF
--- a/src/VASL/LOS/counters/CounterMetadataFile.java
+++ b/src/VASL/LOS/counters/CounterMetadataFile.java
@@ -72,12 +72,10 @@ public class CounterMetadataFile {
 
     public CounterMetadataFile() {
 
-        InputStream inputStream = null;
         DataArchive archive = GameModule.getGameModule().getDataArchive();
-        try {
+        try (InputStream inputStream = archive.getInputStream(counterMetadataFileName)) {
 
             // counter metadata
-            inputStream = archive.getInputStream(counterMetadataFileName);
             parseCounterMetadataFile(inputStream);
 
             // give up on any errors
@@ -90,9 +88,6 @@ public class CounterMetadataFile {
         } catch (NullPointerException e) {
             metadataElements = null;
             ErrorDialog.bug(e);
-        }
-        finally {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/src/VASL/build/module/ASLChatter.java
+++ b/src/VASL/build/module/ASLChatter.java
@@ -261,7 +261,7 @@ public class ASLChatter extends VASSAL.build.module.Chatter
         }
         );
 
-        RemoveActionForKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK));
+        RemoveActionForKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK));
         RemoveActionForKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
 
         m_objChatPanel.addComponentListener(new ComponentAdapter()
@@ -272,18 +272,18 @@ public class ASLChatter extends VASSAL.build.module.Chatter
             }
         });
 
-        m_btnStats = CreateStatsDiceButton("stat.png", "", "Dice rolls stats", KeyStroke.getKeyStroke(KeyEvent.VK_F3, InputEvent.CTRL_MASK));
+        m_btnStats = CreateStatsDiceButton("stat.png", "", "Dice rolls stats", KeyStroke.getKeyStroke(KeyEvent.VK_F3, InputEvent.CTRL_DOWN_MASK));
         m_btnDR = CreateChatterDiceButton("DRs.gif", "DR", "DR", KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0), true, ASLDiceBot.OTHER_CATEGORY);
-        m_btnIFT = CreateChatterDiceButton("", "IFT", "IFT attack DR", KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "IFT");
-        m_btnTH = CreateChatterDiceButton("", "TH", "To Hit DR", KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "TH");
-        m_btnTK = CreateChatterDiceButton("", "TK", "To Kill DR", KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "TK");
-        m_btnMC = CreateChatterDiceButton("", "MC", "Morale Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "MC");
-        m_btnRally = CreateChatterDiceButton("", "Rally", "Rally DR", KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "Rally");
-        m_btnCC = CreateChatterDiceButton("", "CC", "Close Combat DR", KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "CC");
-        m_btnTC = CreateChatterDiceButton("", "TC", "Task Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), true, "TC");
+        m_btnIFT = CreateChatterDiceButton("", "IFT", "IFT attack DR", KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "IFT");
+        m_btnTH = CreateChatterDiceButton("", "TH", "To Hit DR", KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "TH");
+        m_btnTK = CreateChatterDiceButton("", "TK", "To Kill DR", KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "TK");
+        m_btnMC = CreateChatterDiceButton("", "MC", "Morale Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "MC");
+        m_btnRally = CreateChatterDiceButton("", "Rally", "Rally DR", KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "Rally");
+        m_btnCC = CreateChatterDiceButton("", "CC", "Close Combat DR", KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "CC");
+        m_btnTC = CreateChatterDiceButton("", "TC", "Task Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), true, "TC");
         m_btndr = CreateChatterDiceButton("dr.gif", "dr", "dr", KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0), false, ASLDiceBot.OTHER_CATEGORY);
-        m_btnSA = CreateChatterDiceButton("", "SA", "Sniper Activation dr", KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), false, "SA");
-        m_btnRS = CreateChatterDiceButton("", "RS", "Random Selection dr", KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK), false, "RS");
+        m_btnSA = CreateChatterDiceButton("", "SA", "Sniper Activation dr", KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), false, "SA");
+        m_btnRS = CreateChatterDiceButton("", "RS", "Random Selection dr", KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK), false, "RS");
 // For the future?        
 //        JButton l_btnThinking = CreateInfoButton("Thinking", "I'm thinking", "I'm thinking", KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK));
 //        JButton l_btnHold = CreateInfoButton("Wait", "Wait, please", "Wait, please", KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK));

--- a/src/VASL/build/module/ASLChatter.java
+++ b/src/VASL/build/module/ASLChatter.java
@@ -1548,7 +1548,7 @@ public class ASLChatter extends VASSAL.build.module.Chatter
 
         if (l_objBackgroundColor_Exist == null)
         {
-            l_objBackgroundColor = new ColorConfigurer(CHAT_BACKGROUND_COLOR, "Backgound color: ", Color.white); //$NON-NLS-1$
+            l_objBackgroundColor = new ColorConfigurer(CHAT_BACKGROUND_COLOR, "Background color: ", Color.white); //$NON-NLS-1$
             l_objModulePrefs.addOption(Resources.getString("Chatter.chat_window"), l_objBackgroundColor); //$NON-NLS-1$
         }
         else

--- a/src/VASL/build/module/ASLCommandEncoder.java
+++ b/src/VASL/build/module/ASLCommandEncoder.java
@@ -554,7 +554,7 @@ class VehicleInfo extends UnitInfo {
     CA = Integer.parseInt(st.nextToken()) - 1;
     TCA = Integer.parseInt(st.nextToken()) - 1;
     unitInfo += st.nextToken();
-    CE = new Boolean(st.nextToken()).booleanValue();
+    CE = Boolean.parseBoolean(st.nextToken());
     super.read(unitInfo);
     int index = back.indexOf(';');
     if (index >= 0) {

--- a/src/VASL/build/module/ASLMap.java
+++ b/src/VASL/build/module/ASLMap.java
@@ -190,13 +190,9 @@ public class ASLMap extends Map {
      */
     private void readMetadata() throws JDOMException {
 
-        InputStream inputStream = null;
-        try {
-
-            DataArchive archive = GameModule.getGameModule().getDataArchive();
-
-            // shared board metadata
-            inputStream =  archive.getInputStream(sharedBoardMetadataFileName);
+        DataArchive archive = GameModule.getGameModule().getDataArchive();
+        // shared board metadata
+        try (InputStream inputStream =  archive.getInputStream(sharedBoardMetadataFileName)) {
             sharedBoardMetadata = new SharedBoardMetadata();
             sharedBoardMetadata.parseSharedBoardMetadataFile(inputStream);
 
@@ -211,10 +207,6 @@ public class ASLMap extends Map {
             sharedBoardMetadata = null;
             throw new JDOMException("Cannot read the shared metadata file", e);
         }
-        finally {
-            IOUtils.closeQuietly(inputStream);
-        }
-
     }
 
     /**

--- a/src/VASL/build/module/CounterPaletteSearch.java
+++ b/src/VASL/build/module/CounterPaletteSearch.java
@@ -53,7 +53,7 @@ public class CounterPaletteSearch extends AbstractBuildable implements GameCompo
         launch.setEnabled(false);
 
         keyListener = new KeyStrokeListener(launchAction);
-        keyListener.setKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.SHIFT_MASK + InputEvent.CTRL_MASK));
+        keyListener.setKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.SHIFT_DOWN_MASK + InputEvent.CTRL_DOWN_MASK));
 
         Search = new JTextField ("Enter Counter Name");
         Search.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -131,14 +131,9 @@ public class CounterPaletteSearch extends AbstractBuildable implements GameCompo
      * read the countersearch metadata
      */
     private void readMetadata() throws JDOMException {
-
-        InputStream inputStream = null;
-        try {
-
-            DataArchive archive = GameModule.getGameModule().getDataArchive();
-
-            // counter finder metadata
-            inputStream =  archive.getInputStream(CounterMetadataFileName);
+        DataArchive archive = GameModule.getGameModule().getDataArchive();
+        // counter finder metadata
+        try (InputStream inputStream =  archive.getInputStream(CounterMetadataFileName)){
             counterfinderMetadata = new CounterFinderMetadata();
             counterfinderMetadata.parseCounterFinderMetadataFile(inputStream);
 
@@ -152,9 +147,6 @@ public class CounterPaletteSearch extends AbstractBuildable implements GameCompo
         } catch (NullPointerException e) {
             counterfinderMetadata = null;
             throw new JDOMException("Cannot read counter finder metadata file", e);
-        }
-        finally {
-            IOUtils.closeQuietly(inputStream);
         }
         // create list of counters that can be searched for - unit, vehicle, gun, plane (most) counters are not searchable
         counterlist = counterfinderMetadata.getCounterTypes();

--- a/src/VASL/build/module/map/ASLCasbin.java
+++ b/src/VASL/build/module/map/ASLCasbin.java
@@ -26,7 +26,7 @@ public class ASLCasbin extends AbstractConfigurable implements KeyListener, Game
     private Buildable pparent;
     private Map map;
     private static final String LINK_KEY = "LinkKey";
-    private KeyStroke linkKey = KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_MASK + InputEvent.ALT_MASK);
+    private KeyStroke linkKey = KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_DOWN_MASK + InputEvent.ALT_GRAPH_DOWN_MASK);
 
     public Class<?>[] getAttributeTypes() {
         return new Class<?>[]{NamedKeyStroke.class};

--- a/src/VASL/build/module/map/ASLDiceOverlay.java
+++ b/src/VASL/build/module/map/ASLDiceOverlay.java
@@ -1055,31 +1055,31 @@ public class ASLDiceOverlay extends AbstractConfigurable implements GameComponen
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "IFT", "IFT attack DR", KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "IFT");
+            c = CreateDiceButton("", "IFT", "IFT attack DR", KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "IFT");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "TH", "To Hit DR", KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "TH");
+            c = CreateDiceButton("", "TH", "To Hit DR", KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "TH");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "TK", "To Kill DR", KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "TK");
+            c = CreateDiceButton("", "TK", "To Kill DR", KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "TK");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "MC", "Morale Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "MC");
+            c = CreateDiceButton("", "MC", "Morale Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "MC");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "R", "Rally DR", KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "Rally");
+            c = CreateDiceButton("", "R", "Rally DR", KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "Rally");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "CC", "Close Combat DR", KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "CC");
+            c = CreateDiceButton("", "CC", "Close Combat DR", KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "CC");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "TC", "Task Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), true, "TC");
+            c = CreateDiceButton("", "TC", "Task Check DR", KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), true, "TC");
             AddButton(p, c, l_iRow++, 10);
             comps.add(c);
 
@@ -1087,11 +1087,11 @@ public class ASLDiceOverlay extends AbstractConfigurable implements GameComponen
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "SA", "Sniper Activation dr", KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), false, "SA");
+            c = CreateDiceButton("", "SA", "Sniper Activation dr", KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), false, "SA");
             AddButton(p, c, l_iRow++, 2);
             comps.add(c);
 
-            c = CreateDiceButton("", "RS", "Random Selection dr", KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_MASK | InputEvent.SHIFT_MASK), false, "RS");
+            c = CreateDiceButton("", "RS", "Random Selection dr", KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), false, "RS");
             AddButton(p, c, l_iRow++, 20);
             comps.add(c);
 

--- a/src/VASL/build/module/map/BoardVersionChecker.java
+++ b/src/VASL/build/module/map/BoardVersionChecker.java
@@ -189,15 +189,9 @@ public class BoardVersionChecker extends AbstractBuildable implements GameCompon
             conn.setUseCaches(false);
 
             //Properties p = new Properties();
-            InputStream input = null;
-            try {
-                input = conn.getInputStream();
+            try (InputStream input = conn.getInputStream()){
                 parseboardversionFile(input);
                 //p.load(input);
-
-            }
-            finally {
-                IOUtils.closeQuietly(input);
             }
 
             //boardVersions = p;
@@ -212,12 +206,8 @@ public class BoardVersionChecker extends AbstractBuildable implements GameCompon
             conn.setUseCaches(false);
 
             Properties p = new Properties();
-            InputStream input = null;
-            try {
-                input = conn.getInputStream();
+            try (InputStream input = conn.getInputStream()){
                 p.load(input);
-            } finally {
-                IOUtils.closeQuietly(input);
             }
 
             overlayVersions = p;
@@ -332,28 +322,21 @@ public class BoardVersionChecker extends AbstractBuildable implements GameCompon
         // Need to disable SNI to read from Github
         System.setProperty("jsse.enableSNIExtension", "false");
 
-        FileOutputStream outFile = null;
-        InputStream in = null;
         try {
 
             URL website = new URL( encodeUrl(url) );
             URLConnection conn = website.openConnection();
             conn.setUseCaches(false);
-
-            in = conn.getInputStream();
-            ReadableByteChannel rbc = Channels.newChannel(in);
-            outFile = new FileOutputStream(fileName);
-            outFile.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-
+            try (FileOutputStream outFile = new FileOutputStream(fileName);
+                InputStream in = conn.getInputStream()) {
+                ReadableByteChannel rbc = Channels.newChannel(in);
+                outFile.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            }
             return true;
 
         } catch (IOException e) {
             // Fail silently on any error
             return false;
-        }
-        finally {
-            IOUtils.closeQuietly(outFile);
-            IOUtils.closeQuietly(in);
         }
     }
     

--- a/src/VASL/build/module/map/HindranceKeeper.java
+++ b/src/VASL/build/module/map/HindranceKeeper.java
@@ -134,7 +134,7 @@ public class HindranceKeeper extends AbstractBuildable implements Drawable, KeyL
   }
 
   public void keyReleased(KeyEvent e) {
-    if (!map.isPiecesVisible() && KeyStroke.getKeyStrokeForEvent(e).equals(KeyStroke.getKeyStroke(KeyEvent.VK_F10, KeyEvent.CTRL_DOWN_MASK, true))) {
+    if (!map.isPiecesVisible() && KeyStroke.getKeyStrokeForEvent(e).equals(KeyStroke.getKeyStroke(KeyEvent.VK_F10, KeyEvent.SHIFT_DOWN_MASK, true))) {
       Configurer config = GameModule.getGameModule().getPrefs().getOption(DRAW_HINDRANCES);
       config.setValue(Boolean.TRUE.equals(config.getValue()) ? Boolean.FALSE : Boolean.TRUE);
       map.getView().repaint();

--- a/src/VASL/build/module/map/HindranceKeeper.java
+++ b/src/VASL/build/module/map/HindranceKeeper.java
@@ -134,7 +134,7 @@ public class HindranceKeeper extends AbstractBuildable implements Drawable, KeyL
   }
 
   public void keyReleased(KeyEvent e) {
-    if (!map.isPiecesVisible() && KeyStroke.getKeyStrokeForEvent(e).equals(KeyStroke.getKeyStroke(KeyEvent.VK_F10, KeyEvent.SHIFT_MASK, true))) {
+    if (!map.isPiecesVisible() && KeyStroke.getKeyStrokeForEvent(e).equals(KeyStroke.getKeyStroke(KeyEvent.VK_F10, KeyEvent.CTRL_DOWN_MASK, true))) {
       Configurer config = GameModule.getGameModule().getPrefs().getOption(DRAW_HINDRANCES);
       config.setValue(Boolean.TRUE.equals(config.getValue()) ? Boolean.FALSE : Boolean.TRUE);
       map.getView().repaint();

--- a/src/VASL/build/module/map/boardPicker/Overlay.java
+++ b/src/VASL/build/module/map/boardPicker/Overlay.java
@@ -137,14 +137,10 @@ public class Overlay implements Cloneable {
             c = 'a';
         }
 
-        InputStream in = null;
-        try {
-            in = archive.getImageInputStream(fileName(name + c));
+        try (InputStream in = archive.getImageInputStream(fileName(name + c))){
             im = ImageIO.read(new MemoryCacheImageInputStream(in));
         } catch (IOException e) {
             e.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(in);
         }
 
         return im;
@@ -164,9 +160,7 @@ public class Overlay implements Cloneable {
     private void readData() throws IOException {
         origins = getDefaultOriginList(name);
 
-        InputStream in = null;
-        try {
-            in = archive.getInputStream("data");
+        try (InputStream in = archive.getInputStream("data")) {
             BufferedReader file = new BufferedReader(new InputStreamReader(in));
             String s;
             while ((s = file.readLine()) != null) {
@@ -184,8 +178,6 @@ public class Overlay implements Cloneable {
                     hex2 = st.nextToken();
                 }
             }
-        } finally {
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/src/VASL/build/module/map/boardPicker/SSROverlay.java
+++ b/src/VASL/build/module/map/boardPicker/SSROverlay.java
@@ -67,16 +67,11 @@ public class SSROverlay extends Overlay {
 
   protected Image loadImage() {
     Image im = null;
-    InputStream in = null;
-    try {
-      in = archive.getImageInputStream(name);
+    try (InputStream in = archive.getImageInputStream(name)){
       im = ImageIO.read(new MemoryCacheImageInputStream(in));
     }
     catch (IOException e) {
       e.printStackTrace();
-    }
-    finally {
-      IOUtils.closeQuietly(in);
     }
 
     return im;

--- a/src/VASL/build/module/map/boardPicker/Underlay.java
+++ b/src/VASL/build/module/map/boardPicker/Underlay.java
@@ -59,15 +59,10 @@ public class Underlay extends SSROverlay {
 
   public Image loadImage() {
     Image underlayImage = null;
-    InputStream in = null;
-    try {
-      in = GameModule.getGameModule().getDataArchive().getInputStream("boardData/" + imageName);
+    try(InputStream in = GameModule.getGameModule().getDataArchive().getInputStream("boardData/" + imageName)) {
       underlayImage = ImageIO.read(new MemoryCacheImageInputStream(in));
     }
     catch (IOException ex) {
-    }
-    finally {
-      IOUtils.closeQuietly(in);
     }
 
     if (underlayImage == null) {

--- a/src/VASL/counters/Concealment.java
+++ b/src/VASL/counters/Concealment.java
@@ -27,6 +27,7 @@ import VASSAL.tools.SequenceEncoder;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.InputEvent;
 
 /**
  * A Concealment counter
@@ -79,7 +80,7 @@ public class Concealment extends Decorator implements EditablePiece {
   protected KeyCommand[] myGetKeyCommands() {
     if (commands == null) {
       commands = new KeyCommand[1];
-      commands[0] = new KeyCommand("Conceal", KeyStroke.getKeyStroke('C', java.awt.event.InputEvent.CTRL_MASK), Decorator.getOutermost(this));
+      commands[0] = new KeyCommand("Conceal", KeyStroke.getKeyStroke('C', InputEvent.CTRL_DOWN_MASK), Decorator.getOutermost(this));
     }
     return owner == null || owner.equals(GameModule.getUserId()) || ObscurableOptions.getInstance().isUnmaskable(owner) ? commands : new KeyCommand[0];
   }

--- a/src/VASL/counters/MarkMoved.java
+++ b/src/VASL/counters/MarkMoved.java
@@ -22,6 +22,7 @@ import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.awt.event.InputEvent;
 
 import javax.swing.KeyStroke;
 
@@ -44,7 +45,7 @@ import VASSAL.tools.imageop.Op;
 public class MarkMoved extends Decorator implements EditablePiece {
   public static final String ID = "moved;";
 
-  private static final KeyStroke markStroke = KeyStroke.getKeyStroke('M', java.awt.event.InputEvent.CTRL_MASK);
+  private static final KeyStroke markStroke = KeyStroke.getKeyStroke('M', InputEvent.CTRL_DOWN_MASK);
   private String markImage;
   private boolean hasMoved = false;
 
@@ -67,7 +68,7 @@ public class MarkMoved extends Decorator implements EditablePiece {
 
   public Object getProperty(Object key) {
     if (Properties.MOVED.equals(key)) {
-      return new Boolean(isMoved());
+      return isMoved();
     }
     else {
       return super.getProperty(key);

--- a/src/VASL/counters/TextInfo.java
+++ b/src/VASL/counters/TextInfo.java
@@ -91,7 +91,7 @@ public class TextInfo extends Decorator implements EditablePiece {
       commands = new KeyCommand[1];
       commands[0] = new KeyCommand(
         "Show Info",
-        KeyStroke.getKeyStroke('I', InputEvent.CTRL_MASK),
+        KeyStroke.getKeyStroke('I', InputEvent.CTRL_DOWN_MASK),
         Decorator.getOutermost(this)
       );
     }

--- a/src/VASL/counters/Turreted.java
+++ b/src/VASL/counters/Turreted.java
@@ -23,6 +23,7 @@ import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.awt.event.InputEvent;
 
 import javax.swing.KeyStroke;
 
@@ -207,7 +208,7 @@ public class Turreted extends Embellishment0 implements EditablePiece {
       commands[c.length]
           = new KeyCommand
               ("BU",
-               KeyStroke.getKeyStroke('B', java.awt.event.InputEvent.CTRL_MASK),
+               KeyStroke.getKeyStroke('B', InputEvent.CTRL_DOWN_MASK),
                Decorator.getOutermost(this));
     }
     return commands;


### PR DESCRIPTION
Only the VASSAL deprecated code left:

[WARNING] /D:/dev/vasl/src/VASL/build/module/map/ASLBoardPicker.java:[129,36] dataError(VASSAL.build.BadDataReport) in VASSAL.tools.ErrorDialog has been deprecated
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/ASLBoardPicker.java:[143,32] dataError(VASSAL.build.BadDataReport) in VASSAL.tools.ErrorDialog has been deprecated
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/ASLBoardPicker.java:[605,28] dataError(VASSAL.build.BadDataReport) in VASSAL.tools.ErrorDialog has been deprecated
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/boardPicker/ASLBoard.java:[132,24] dataError(VASSAL.build.BadDataReport) in VASSAL.tools.ErrorDialog has been deprecated
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/boardPicker/Overlay.java:[140,38] getImageInputStream(java.lang.String) in VASSAL.tools.DataArchive has been deprecated and marked for removal
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/boardPicker/Overlay.java:[192,35] getImageSize(java.lang.String) in VASSAL.tools.DataArchive has been deprecated and marked for removal
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/boardPicker/SSROverlay.java:[70,34] getImageInputStream(java.lang.String) in VASSAL.tools.DataArchive has been deprecated and marked for removal
[WARNING] /D:/dev/vasl/src/VASL/build/module/map/boardPicker/Underlay.java:[70,32] getImage(java.lang.String) in VASSAL.tools.DataArchive has been deprecated and marked for removal
[WARNING] /D:/dev/vasl/src/VASL/counters/Turreted.java:[115,19] getCurrentImage() in VASSAL.counters.Embellishment0 has been deprecated and marked for removal
