### PR TITLE
Updated vassalengine.org maven repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <repositories>
         <repository>
             <id>vassal</id>
-            <url>http://www.vassalengine.org/maven</url>
+            <url>https://vassalengine.org/maven</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Our maven repo URL has changed---it uses HTTPS now and there's no `www`. The old one will still work for a while, but it would be good to update to the current one.