### PR TITLE
Use new TilingHandler interface in Vassal 3.6.4

### DIFF
--- a/src/VASL/build/module/map/ASLBoardPicker.java
+++ b/src/VASL/build/module/map/ASLBoardPicker.java
@@ -452,8 +452,7 @@ public class ASLBoardPicker extends BoardPicker implements ActionListener  {
                 fpath.getAbsolutePath(),
                 new File(Info.getCacheDir(), "tiles/" + hstr),
                 new Dimension(256, 256),
-                1024,
-                42
+                1024
         );
 
         try {

--- a/src/VASL/build/module/map/ASLTilingHandler.java
+++ b/src/VASL/build/module/map/ASLTilingHandler.java
@@ -53,16 +53,6 @@ public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
   }
 
   @Override
-  protected Dimension getImageSize(DataArchive archive, String iname)
-                                                           throws IOException {
-    try (InputStream in = archive.getInputStream(iname)){
-      final Dimension id = ImageUtils.getImageSize(iname, in);
-      in.close();
-      return id;
-    }
-  }
-
-  @Override
   protected Pair<Integer,Integer> findImages(
     DataArchive archive,
     FileStore tcache,

--- a/src/VASL/build/module/map/ASLTilingHandler.java
+++ b/src/VASL/build/module/map/ASLTilingHandler.java
@@ -47,10 +47,9 @@ public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
     String aname,
     File cdir,
     Dimension tdim,
-    int mhlim,
-    int pid)
+    int mhlim)
   {
-    super(aname, cdir, tdim, mhlim);  //pid
+    super(aname, cdir, tdim, mhlim);
   }
 
   @Override
@@ -74,10 +73,12 @@ public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
     // png code - June 2019 allows board image files to be in either png or gif format
     BoardArchive VASLBoardArchive = new BoardArchive(fa.getName(), "", ASLMap.getSharedBoardMetadata());
     String imagename;
-    if (VASLBoardArchive.isLegacyBoard()){
+    if (VASLBoardArchive.isLegacyBoard()) {
       imagename = fa.getFile().getName() + ".gif";
-    } else
+    }
+    else {
       imagename = VASLBoardArchive.getBoardImageFileName();
+    }
     final String iname = imagename;
     //
     int maxpix = 0; // number of pixels in the largest image
@@ -113,7 +114,7 @@ public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
       }
     }
 
-    return new Pair<Integer,Integer>(tcount, maxpix);
+    return new Pair<>(tcount, maxpix);
   }
 
   @Override

--- a/src/VASL/build/module/map/ASLTilingHandler.java
+++ b/src/VASL/build/module/map/ASLTilingHandler.java
@@ -5,50 +5,25 @@ import static VASSAL.tools.image.tilecache.ZipFileImageTilerState.TILE_WRITTEN;
 import static VASSAL.tools.image.tilecache.ZipFileImageTilerState.TILING_FINISHED;
 
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import VASL.build.module.ASLMap;
 import VASL.build.module.map.boardArchive.BoardArchive;
 import VASL.build.module.map.boardPicker.VASLBoard;
-import VASSAL.Info;
+
 import VASSAL.launch.TilingHandler;
-import VASSAL.build.GameModule;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.image.ImageUtils;
 import VASSAL.tools.image.tilecache.TileUtils;
 import VASSAL.tools.io.FileArchive;
 import VASSAL.tools.io.FileStore;
-import org.apache.commons.io.IOUtils;
-import VASSAL.tools.io.InputOutputStreamPump;
-import VASSAL.tools.io.InputStreamPump;
-import VASSAL.tools.io.ProcessLauncher;
-import VASSAL.tools.io.ProcessWrapper;
 import VASSAL.tools.lang.Pair;
-import VASSAL.tools.swing.EDT;
-import VASSAL.tools.swing.ProgressDialog;
-import VASSAL.tools.swing.Progressor;
 
 public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
-  public ASLTilingHandler(
-    String aname,
-    File cdir,
-    Dimension tdim,
-    int mhlim)
-  {
+  public ASLTilingHandler(String aname, File cdir, Dimension tdim, int mhlim) {
     super(aname, cdir, tdim, mhlim);
   }
 
@@ -108,96 +83,30 @@ public class ASLTilingHandler extends VASSAL.launch.TilingHandler {
   }
 
   @Override
-  protected void runSlicer(List<String> multi, final int tcount, int maxheap)
-                                   throws CancellationException, IOException {
-
-    final InetAddress lo = InetAddress.getByName(null);
-    try (final ServerSocket ssock = new ServerSocket(0, 0, lo)) {
-      final int port = ssock.getLocalPort();
-      final List<String> args = new ArrayList<String>();
-      args.addAll(Arrays.asList(new String[]{
-              String.valueOf(Info.getJavaBinPath()),
-              "-classpath",
-              System.getProperty("java.class.path"),
-              "-Xmx" + maxheap + "M",
-              "-DVASSAL.id=",
-              "-Duser.home=" + System.getProperty("user.home"),
-              "-DVASSAL.port=" + port,
-              "VASSAL.tools.image.tilecache.ZipFileImageTiler",
-              aname,
-              cdir.getAbsolutePath(),
-              String.valueOf(tdim.width),
-              String.valueOf(tdim.height)
-      }));
-
-      args.addAll(multi);
-
-      // set up the process
-      final InputStreamPump outP = new InputOutputStreamPump(null, System.out);
-      final InputStreamPump errP = new InputOutputStreamPump(null, System.err);
-
-      final ProcessWrapper proc = new ProcessLauncher().launch(
-              null,
-              outP,
-              errP,
-              args.toArray(new String[args.size()])
-      );
-
-      // write the image paths to child's stdin, one per line
-      try (PrintWriter stdin = new PrintWriter(proc.stdin)) {
-
-        for (String m : multi) {
-          stdin.println(m);
-        }
+  protected StateMachineHandler createStateMachineHandler(int tcount, Future<Integer> fut) {
+    return new StateMachineHandler() {
+      @Override
+      public void handleStart() {
       }
 
-      try (Socket csock = ssock.accept();
-           DataInputStream in = new DataInputStream(csock.getInputStream())) {
-
-        csock.shutdownOutput();
-        boolean done = false;
-        byte type;
-        while (!done) {
-          type = in.readByte();
-
-          switch (type) {
-            case STARTING_IMAGE:
-              in.readUTF();
-              break;
-
-            case TILE_WRITTEN:
-              break;
-
-            case TILING_FINISHED:
-              done = true;
-              break;
-
-            default:
-              throw new IllegalStateException("bad type: " + type);
-          }
-        }
-
-        in.close();
-        csock.close();
-        ssock.close();
-      } catch (IOException e) {
-
+      @Override
+      public void handleStartingImageState(String ipath) {
       }
 
-      // wait for the tiling process to end
-      try {
-        final int retval = proc.future.get();
-        if (retval != 0) {
-          throw new IOException("return value == " + retval);
-        }
+      @Override
+      public void handleTileWrittenState() {
       }
-      catch (ExecutionException e) {
-        // should never happen
-        throw new IllegalStateException(e);
+
+      @Override
+      public void handleTilingFinishedState() {
       }
-      catch (InterruptedException e) {
-        // should never happen
-        throw new IllegalStateException(e);
+
+      @Override
+      public void handleSuccess() {
+      }
+
+      @Override
+      public void handleFailure() {
       }
     }
   }


### PR DESCRIPTION
This adjusts the ASLTilingHandler to use a newer internal TilingHandler interface which is much simpler than the previous one. Don't merge this before Vassal 3.6.4 is released.