### PR TITLE
Updated Vassal dependency to 3.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.vassalengine</groupId>
             <artifactId>vassal-app</artifactId>
-            <version>3.6.4</version>
+            <version>3.6.6</version>
         </dependency>
 
         <!-- We do not have any tests yet, but time will tell... -->


### PR DESCRIPTION
This PR advances the version of Vassal to 3.6.6.