### PR TITLE
Use --release instead of --source and --target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,7 @@
                 <version>3.3</version>
                 <configuration>
                     <verbose>true</verbose>
-                    <source>11</source>
-                    <target>11</target>
+                    <release>11</release>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>


### PR DESCRIPTION
 This ensures that the -bootclasspath is also set, to prevent accidental use of APIs not present in the specified release.

See https://stackoverflow.com/a/43103038/181106 for details.