### PR TITLE
Set source encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Using any encoding other than UTF-8 these days is asking for trouble. Everyone will expect and write UTF-8 and you'll end up with mangled source files if you try to read them as cp1252.