### PR TITLE
Check MAYBE_MOVED in addition to MOVED, for Vassal 3.7 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.vassalengine</groupId>
             <artifactId>vassal-app</artifactId>
-            <version>3.6.17</version>
+            <version>3.6.19</version>
         </dependency>
 
         <!-- We do not have any tests yet, but time will tell... -->
@@ -100,7 +100,7 @@
                     <arguments>
                         <argument>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</argument>
                         <argument>-jar</argument>
-                        <argument>Vengine-3.6.17.jar</argument>
+                        <argument>Vengine-3.6.19.jar</argument>
                         <argument>--standalone</argument>
                         <argument>target/${project.build.finalName}.jar</argument>
                     </arguments>

--- a/src/VASL/counters/MarkMoved.java
+++ b/src/VASL/counters/MarkMoved.java
@@ -76,7 +76,7 @@ public class MarkMoved extends Decorator implements EditablePiece {
   }
 
   public void setProperty(Object key, Object val) {
-    if (Properties.MOVED.equals(key)) {
+    if (Properties.MOVED.equals(key) || Properties.MAYBE_MOVED.equals(key)) {
       setMoved(Boolean.TRUE.equals(val));
     }
     else {


### PR DESCRIPTION
Vassal 3.7 indicates moves using `MAYBE_MOVED` in some cases where `MOVED` had been used before; checking for `MAYBE_MOVED` preserves the "mark moved" behavior of pieces.