### PR TITLE
Rename jar to vmod; update maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <verbose>true</verbose>
                     <release>11</release>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>rename-file</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>rename</goal>
+                        </goals>
+                        <configuration>
+                            <sourceFile>${project.build.directory}/${project.build.finalName}.jar</sourceFile>
+                            <destinationFile>${project.build.directory}/${project.build.finalName}.vmod</destinationFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR pulls in two changes from vassal-module-template:

* The output file is now renamed from .jar to .vmod, so you no longer need to do this manually.
* The maven-compiler-plugin is updated to version 3.11.0.