### PR TITLE
Changed propertiesFilter so that concealed sw would not be highlighted (issue 1802)

### DIFF
--- a/src/VASL/build/module/map/ASLBrokenFinder.java
+++ b/src/VASL/build/module/map/ASLBrokenFinder.java
@@ -82,7 +82,7 @@ public class ASLBrokenFinder extends AbstractConfigurable implements GameCompone
             this.m_objMap = (Map) parent;
             m_objMap.addDrawComponent(this);
             
-            m_piecePropertiesFilter.setExpression("InvisibleToOthers != true && BRK_Active = true || PieceName = DM || PieceName = Disrupt");
+            m_piecePropertiesFilter.setExpression("InvisibleToOthers != true && BRK_Active = true && ObscuredToOthers != true || PieceName = DM || PieceName = Disrupt");
         }
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `ASLBrokenFinder` class in the `VASL` module. The change modifies the filter expression used to determine which pieces are considered broken.

* [`src/VASL/build/module/map/ASLBrokenFinder.java`](diffhunk://#diff-f5d4181356c236106f9e35aa83887978b76c9dd6592ae1499a6a67b072f9deecL85-R85): Updated the `m_piecePropertiesFilter` expression to include a check for `ObscuredToOthers` property.