### PR TITLE
Fixed bug when moving a concealment counter unconceals counters that shouldnt be

### DIFF
--- a/src/VASL/counters/Concealment.java
+++ b/src/VASL/counters/Concealment.java
@@ -112,12 +112,16 @@ public class Concealment extends Decorator implements EditablePiece {
           if (getParent() == null) {
             lastIndex--;
           }
-          for (int i = lastIndex; i > newIndex; --i) {
+          // Start at the top of the stack and stop at soon as you encounter a concealment counter
+          for (int i = getParent().getPieceCount()-1; i > newIndex; --i) {
             GamePiece child = parent.getPieceAt(i);
             if (Decorator.getDecorator(child, Concealment.class) != null) {
               break;
             }
-            c.append(setConcealed(child, false));
+            // Only modify counters that were below the moved counter
+            if ( i <= lastIndex) {
+              c.append(setConcealed(child, false));
+            }
           }
         }
         tracker.repaint();


### PR DESCRIPTION
The code looked at counters below the old location of the concealment counter and did not consider if there was another ? counter above them. I made a slight change so that when a concealment counter is moved within a stack, we look at the top of the stack to see if there are any other concealment counters, if there are, then we dont change the concealment status of the counters below them.


closes #1848