### PR TITLE
Broken concealed weapons were still being revealed by the Show/hide broken/malf button

### DIFF
--- a/src/VASL/build/module/map/ASLBrokenFinder.java
+++ b/src/VASL/build/module/map/ASLBrokenFinder.java
@@ -82,7 +82,7 @@ public class ASLBrokenFinder extends AbstractConfigurable implements GameCompone
             this.m_objMap = (Map) parent;
             m_objMap.addDrawComponent(this);
             
-            m_piecePropertiesFilter.setExpression("InvisibleToOthers != true && BRK_Active = true || PieceName = DM || PieceName = Disrupt");
+            m_piecePropertiesFilter.setExpression("InvisibleToOthers != true && BRK_Active = true && ObscuredToOthers != true || PieceName = DM || PieceName = Disrupt");
         }
     }
 


### PR DESCRIPTION
Added an expression in the properties filter so that counters that are concealed do not get revealed 

close #1802  