### PR TITLE
Changed conditional check in vertexadj section of LOSStatus

### DIFF
--- a/src/VASL/LOS/Map/Map.java
+++ b/src/VASL/LOS/Map/Map.java
@@ -1265,11 +1265,12 @@ public class Map  {
             currentHex = sourceHex;
             // code to fix vertex los
             int vertexadj = 0;
-            if (!source.equals(sourceHex.getCenterLocation()) && sourceHex.isDepressionTerrain()){
+            if (!source.isCenterLocation() && sourceHex.isDepressionTerrain()){
                 vertexadj =1;
             }
+            vertexadj = 0;
             sourceElevation = sourceHex.getBaseHeight() + source.getBaseHeight() + vertexadj;
-            if (!target.equals(targetHex.getCenterLocation()) && targetHex.isDepressionTerrain()){
+            if (!target.isCenterLocation() && targetHex.isDepressionTerrain()){
                 vertexadj=1;
             }
             targetElevation = targetHex.getBaseHeight() + target.getBaseHeight() + vertexadj;


### PR DESCRIPTION
Change was necessary to resolve situation of depression hexes containing multiple center locations. For example a gully hex with a bridge. The sourceHex.getCenterLocation() only returned true when taken from the location below the bridge, and false when taken from on the bridge. This lead to bad results where the level was increased by one 



closes #1799 